### PR TITLE
Update aws-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,6 @@ RUN apt-get update && apt-get install -y \
 RUN curl -L https://github.com/github/hub/releases/download/v2.2.1/hub-linux-386-2.2.1.tar.gz | tar zxvf -
 RUN cp hub-linux-386-2.2.1/hub /usr/local/bin/hub
 
-RUN curl -L https://dl.bintray.com/mitchellh/terraform/terraform_0.6.6_linux_amd64.zip -O
-RUN unzip terraform_0.6.6_linux_amd64.zip -d terraform-dir
-RUN cp -R terraform-dir/* /usr/local/bin
-
 RUN curl -L https://www.opscode.com/chef/install.sh | sudo bash -s -- -P chefdk
 
 RUN echo 'eval "$(chef shell-init bash)"' > /etc/profile.d/chefdk.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y \
 RUN curl -L https://github.com/github/hub/releases/download/v2.2.1/hub-linux-386-2.2.1.tar.gz | tar zxvf -
 RUN cp hub-linux-386-2.2.1/hub /usr/local/bin/hub
 
-RUN curl -L https://www.opscode.com/chef/install.sh | sudo bash -s -- -P chefdk
+RUN curl -L https://www.opscode.com/chef/install.sh | bash -s -- -P chefdk
 
 RUN echo 'eval "$(chef shell-init bash)"' > /etc/profile.d/chefdk.sh
 ENV PATH "/opt/chefdk/bin:/root/.chefdk/gem/ruby/2.1.0/bin:/opt/chefdk/embedded/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
The `aws autoscaling detach` command of aws-cli 1.9.7 does not support for the long instance ID format of AWS EC2.

I tried to build a Docker image to update aws-cli but it failed.
Terraform v 0.6.6 was too old to install, but since it is not currently used by CrowdWorks. So, I deleted terraform.

This repository should also be renamed to docker-chef, but since it is greatly affected, we do not deal with this pull request.

Also, although the sudo command was not found, sudo is unnecessary because it is installed as root. I deleted it together.