### PR TITLE
Pin sshkit version to v1.7.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN chef gem install \
     kitchen-vagrant \
     serverspec \
     rake \
-    sshkit \
+    sshkit:1.7.1 \
     joumae:0.2.7
 
 RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 > /usr/local/bin/jq && \


### PR DESCRIPTION
Incompatible changes in sshkit v1.9.0 no longer automatically load DSL.
For the moment we fix sshkit to v1.7.1 which was working previously.
refs: https://github.com/capistrano/sshkit/blob/master/CHANGELOG.md#190rc1